### PR TITLE
Move to PostCSS 5.0 API

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function(options) {
   ]
 
   return function(style) {
-    style.eachDecl(function(decl) {
+    style.walkDecls(function(decl) {
       if (!decl.value ||
           decl.value.indexOf("rgba") === -1 ||
           properties.indexOf(decl.prop) === -1

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "color-string": "^0.3.0",
-    "postcss": "^4.1.16"
+    "postcss": "^5.0.0"
   },
   "devDependencies": {
     "css-whitespace": "^1.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -28,8 +28,8 @@ test("hex", function(t) {
   compareFixtures(t, "rgba-double-fallback", "should transform rgba")
   compareFixtures(t, "no-rgba-fallback", "should not transform rgba")
   compareFixtures(t, "rgba-fallback-option", "should transform rgba in shadow",
-  {
-    properties:["box-shadow"],
-  })
+    {
+      properties:["box-shadow"],
+    })
   t.end()
 })


### PR DESCRIPTION
PostCSS 5.0 API has breaking changes (mainly with `each*` -> `walk*`), so if you merge this you’ll want to bump a major version for the npm module :-)