### PR TITLE
Update `properties` defaults in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ body {
 
 postcss-color-rgba-fallback accepts option
 
-##### `properties` (default:  - `> ["background-color","background","color","border","border-color","outline","outline-color]`)
+##### `properties`
+default: `
+[ "background-color",
+  "background",
+  "color",
+  "border",
+  "border-color",
+  "outline",
+  "outline-color ]
+`
 
 Allows you to specify your whitelist of properties.
 **This option enables adding a fallback for one or a properties list**


### PR DESCRIPTION
Hello,

The default values for the `properties` option looks a bit confusing IMO.

Before:
![selection_002](https://cloud.githubusercontent.com/assets/335467/9739568/ad6faf1e-5650-11e5-83e8-65a019406a1c.png)

After:
![selection_001](https://cloud.githubusercontent.com/assets/335467/9739574/b4c00f8e-5650-11e5-9ac8-7b70364af6fd.png)

