### PR TITLE
Add optional old IE filter fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ body {
 
 ## Node.js options
 
-postcss-color-rgba-fallback accepts option
+postcss-color-rgba-fallback accepts options
 
 ##### `properties`
 default: `
@@ -64,6 +64,21 @@ default: `
 
 Allows you to specify your whitelist of properties.
 **This option enables adding a fallback for one or a properties list**
+
+
+##### `oldie`
+default: `false`
+
+Whether to add old IE proprietary filter fallback.
+
+
+##### `oldieProperties`
+default: `
+[ "background-color",
+  "background" ]`
+
+Allows you to specify your whitelist of properties eligible for old IE fallback.
+
 
 Checkout [tests](test) for more examples.
 

--- a/index.js
+++ b/index.js
@@ -2,35 +2,37 @@
  * Module dependencies.
  */
 var postcss = require("postcss")
+var objectAssign = require("object-assign")
+var rgbaRegex = require("rgba-regex")
 var colorString = require("color-string")
-
-/**
- * Constantes
- */
-var RGBA = /rgba\s*\((\s*(\d+)\s*(,)\s*){3}(\s*(\d?\.\d+)\s*)\)$/i
 
 /**
  * PostCSS plugin to transform rgba() to hexadecimal
  */
 module.exports = postcss.plugin("postcss-color-rgba-fallback",
 function(options) {
-  options = options || {}
-
-  var properties = options.properties || [
-    "background-color",
-    "background",
-    "color",
-    "border",
-    "border-color",
-    "outline",
-    "outline-color",
-  ]
+  options = objectAssign({}, {
+    oldie: false,
+    properties: [
+      "background-color",
+      "background",
+      "color",
+      "border",
+      "border-color",
+      "outline",
+      "outline-color",
+    ],
+    oldieProperties: [
+      "background-color",
+      "background",
+    ],
+  }, options)
 
   return function(style) {
     style.walkDecls(function(decl) {
       if (!decl.value ||
           decl.value.indexOf("rgba") === -1 ||
-          properties.indexOf(decl.prop) === -1
+          options.properties.indexOf(decl.prop) === -1
       ) {
         return
       }
@@ -44,9 +46,25 @@ function(options) {
         return
       }
 
-      var value = transformRgba(decl.value)
-      if (value) {
-        decl.cloneBefore({value: value})
+      var fallback = transformRgba(decl.value)
+      if (fallback) {
+        decl.cloneBefore({value: fallback})
+      }
+
+      if (!options.oldie ||
+          options.oldieProperties.indexOf(decl.prop) === -1
+      ) {
+        return
+      }
+
+      var ieFilter = formatIeFilter(decl.value, fallback)
+
+      if (ieFilter) {
+        var gteIE8 = postcss.decl({prop: "-ms-filter", value: quote(ieFilter)})
+        var ltIE8 = postcss.decl({prop: "filter", value: ieFilter})
+
+        decl.parent.insertBefore(decl, gteIE8)
+        decl.parent.insertBefore(decl, ltIE8)
       }
     })
   }
@@ -59,14 +77,51 @@ function(options) {
  * @return {String}        converted declaration value to hexadecimal
  */
 function transformRgba(string) {
-  var value = RGBA.exec(string)
+  var value = rgbaRegex().exec(string)
+
   if (!value) {
     return
   }
 
   var rgb = colorString.getRgb(value[0])
   var hex = colorString.hexString(rgb)
-  hex = string.replace(RGBA, hex)
+  hex = string.replace(rgbaRegex(), hex)
 
   return (hex)
+}
+
+/**
+ * Format old IE filter value.
+ *
+ * @param  {String} value    rgba raw value
+ * @param  {String} fallback hex converted value
+ * @return {String}          formatted IE filter
+ */
+function formatIeFilter(value, fallback) {
+  var matches = rgbaRegex().exec(value)
+
+  if (!matches) {
+    return
+  }
+
+  var alpha = matches[4]
+
+  if (!alpha || alpha === "1") {
+    return
+  }
+
+  var hex = fallback.replace("#", "#" + Math.round(255 * alpha).toString(16))
+
+  return ("progid:DXImageTransform.Microsoft.gradient(startColorStr="
+          + hex + ", endColorStr=" + hex + ")")
+}
+
+/**
+ * Force double quote a string.
+ *
+ * @param  {String} str input string
+ * @return {String}     double quoted string
+ */
+function quote(str) {
+  return ("\"" + str + "\"")
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   ],
   "dependencies": {
     "color-string": "^0.3.0",
-    "postcss": "^5.0.0"
+    "object-assign": "^4.0.1",
+    "postcss": "^5.0.0",
+    "rgba-regex": "^1.0.0"
   },
   "devDependencies": {
     "css-whitespace": "^1.1.0",

--- a/test/fixtures/rgba-oldie-fallback.css
+++ b/test/fixtures/rgba-oldie-fallback.css
@@ -1,0 +1,6 @@
+body {
+  background: rgba(153, 221, 153, 0.8);
+  font-size:1px;
+  border: solid 1px rgba(100,102,103,.3);
+  color: rgba(0, 0, 0, .4);
+}

--- a/test/fixtures/rgba-oldie-fallback.expected.css
+++ b/test/fixtures/rgba-oldie-fallback.expected.css
@@ -1,0 +1,11 @@
+body {
+  background: #99DD99;
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#cc99DD99, endColorStr=#cc99DD99)";
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#cc99DD99, endColorStr=#cc99DD99);
+  background: rgba(153, 221, 153, 0.8);
+  font-size:1px;
+  border: solid 1px #646667;
+  border: solid 1px rgba(100,102,103,.3);
+  color: #000000;
+  color: rgba(0, 0, 0, .4);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -31,5 +31,9 @@ test("hex", function(t) {
     {
       properties:["box-shadow"],
     })
+  compareFixtures(t, "rgba-oldie-fallback", "should add old IE filters",
+    {
+      oldie: true,
+    })
   t.end()
 })


### PR DESCRIPTION
Refs: #15 

Questions:
- I added IE8 as well as < IE8 support, should we or just stop at 8 ?

Notes:
- I had to replace the Regex as it was erroneous and did not returned the rgba parameters correctly.

All together it adds a bit of complexity to the plugin, still acceptable IMO.
