### PR TITLE
Feature/postcss value parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.1.0 - 2015-10-07
+
+- Added: postcss-value-parser v3.0.2
+- Removed: colorString
+- Removed: `RGBA` regular expression
+- Removed: `transformRgba` function
+- Updated: hexadecimal value is lowercase
+- Updated: tests and documentation
+
 # 2.0.0 - 2015-09-06
 
 - Removed: compatibility with postcss v4.x

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ you will get:
 
 ```css
 body {
-  background: #99DD99;
+  background: #99dd99;
   background: rgba(153, 221, 153, 0.8);
   border: solid 1px #646667;
   border: solid 1px rgba(100,102,103,.3);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "index.js"
   ],
   "dependencies": {
-    "color-string": "^0.3.0",
-    "postcss": "^5.0.0"
+    "postcss": "^5.0.0",
+    "postcss-value-parser": "^3.0.2"
   },
   "devDependencies": {
     "css-whitespace": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-color-rgba-fallback",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "PostCSS plugin to transform rgba() to hexadecimal",
   "keywords": [
     "css",

--- a/test/fixtures/rgba-double-fallback.expected.css
+++ b/test/fixtures/rgba-double-fallback.expected.css
@@ -1,5 +1,5 @@
 .foo {
-  background: #99DD99;
+  background: #99dd99;
   background: rgba(153, 221, 153, 0.8);
   background: rgba(153, 221, 153, 0.8);
   font-size:1px;

--- a/test/fixtures/rgba-fallback.expected.css
+++ b/test/fixtures/rgba-fallback.expected.css
@@ -1,5 +1,5 @@
 body {
-  background: #99DD99;
+  background: #99dd99;
   background: rgba(153, 221, 153, 0.8);
   font-size:1px;
   border: solid 1px #646667;


### PR DESCRIPTION
- Added: postcss-value-parser v3.0.2
- Removed: colorString
- Removed: `RGBA` regular expression
- Removed: `transformRgba` function
- Updated: hexadecimal value is lowercase
- Updated: tests and documentation

Bumps major release because hexadecimal lowercase changed tests